### PR TITLE
feat: add WorkExperience component and integrate it into Home screen

### DIFF
--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -73,7 +73,7 @@ export const WorkExperience = () => {
                   <p className="text-xs sm:text-sm text-[#596170] mb-3">
                     {exp.period}
                   </p>
-                  <p className="text-xs sm:text-large text-gray-300 leading-relaxed mb-3">
+                  <p className="text-xs sm:text-lg text-gray-300 leading-relaxed mb-3">
                     {exp.description}
                   </p>
 

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -1,0 +1,98 @@
+import { useTranslation } from "react-i18next";
+
+interface Experience {
+  title: string;
+  company: string;
+  period: string;
+  description: string;
+  technologies: string[];
+}
+
+export const WorkExperience = () => {
+  const { t } = useTranslation("global");
+
+  const experiences: Experience[] = [
+    {
+      title: "Full Stack Developer",
+      company: "INFĒRA",
+      period: "2024 - Presente",
+      description:
+        "At INFĒRA, I’ve been responsible for maintaining and improving the company’s mobile application. I migrated the project to a newer version of Expo, simplifying dependency management and ensuring long-term stability. I also identified and resolved key bugs to deliver a more reliable React Native app. On the backend, I developed new PHP endpoints to expand the system’s features and strengthen integration with the frontend.",
+      technologies: ["React Native", "PHP", "MySQL", "Expo"],
+    },
+    {
+      title: "Frontend Developer",
+      company: "Beach Point Med",
+      period: "2023 - 2024",
+      description:
+        "As a Front-End Developer at BeachPointMed, I enhanced the user experience by building an efficient routing system and optimizing the interface for performance and usability. I implemented reusable styles and components to maintain a consistent design and accelerate development. Additionally, I defined a modular and scalable architecture, organizing routes and components for easier maintenance and future growth of the application.",
+      technologies: ["React", "Typescript", "CSS3", "Figma", "Tailwind CSS"],
+    },
+    {
+      title: "No-Code Developer",
+      company: "Dream Ventures Studio",
+      period: "2023 - 2023",
+      description:
+        "I developed over 20 high-converting landing pages using Bubble.io within just two months. My work helped the company achieve rapid early growth and build client trust through visually appealing and results-driven web experiences.",
+      technologies: ["Bubble.io"],
+    },
+  ];
+
+  return (
+    <section className="min-h-screen bg-[#000] py-16 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-7xl mx-auto">
+        <h2 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-center mb-16">
+          <span className="text-white">{t("WorkExperience.Work")} </span>
+          <span className="text-[#596170]">
+            {t("WorkExperience.Experience")}
+          </span>
+        </h2>
+
+        {/* Timeline */}
+        <div className="relative">
+          <div className="absolute left-8 sm:left-12 w-0.5 h-full bg-[#596170]" />
+
+          {/* Experiences */}
+          <div className="space-y-12 lg:space-y-16">
+            {experiences.map((exp, index) => (
+              <div key={index} className="relative flex items-start gap-8">
+                <div className="flex-shrink-0 w-16 sm:w-24 flex justify-center">
+                  <div className="w-5 h-5 bg-purple-600 rounded-full border-4 border-[#000] z-10 mt-1" />
+                </div>
+
+                <div
+                  className="flex-1 opacity-0 animate-[fadeIn_0.8s_ease-in_forwards]"
+                  style={{ animationDelay: `${index * 0.2}s` }}
+                >
+                  <h3 className="text-lg sm:text-xl font-bold text-white mb-1.5">
+                    {exp.title}
+                  </h3>
+                  <p className="text-base sm:text-lg font-semibold text-[#828b9c] mb-1">
+                    {exp.company}
+                  </p>
+                  <p className="text-xs sm:text-sm text-[#596170] mb-3">
+                    {exp.period}
+                  </p>
+                  <p className="text-xs sm:text-large text-gray-300 leading-relaxed mb-3">
+                    {exp.description}
+                  </p>
+
+                  <div className="flex flex-wrap gap-2">
+                    {exp.technologies.map((tech, techIndex) => (
+                      <span
+                        key={techIndex}
+                        className="px-2 py-1 bg-purple-600/20 text-purple-300 text-xs rounded-md border border-purple-600/30"
+                      >
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { NavBar } from "../components/NavBar";
 import { Welcome } from "../components/Welcome";
+import { WorkExperience } from "../components/WorkExperience";
 
 export const Home = () => {
   const aboutMeRef = useRef<HTMLDivElement>(null);
@@ -20,7 +21,7 @@ export const Home = () => {
           <Welcome />
         </div>
         <div ref={workExperienceRef} id="workExperience">
-          {/* <WorkExperience /> */}
+          <WorkExperience />
         </div>
         <div ref={projectsRef} id="projects">
           {/* <Projects /> */}


### PR DESCRIPTION
This pull request introduces a new `WorkExperience` component and integrates it into the `Home` screen, providing a visually appealing and structured timeline of professional experience. The component displays multiple job roles, their descriptions, and associated technologies, with support for internationalization via `react-i18next`.

**Component Addition and Integration**

* Added a new `WorkExperience` component in `src/components/WorkExperience.tsx` that renders a timeline of experiences, including job title, company, period, description, and technologies used. The component uses internationalization and custom styling for a modern look.
* Imported and rendered the `WorkExperience` component in the `Home` screen (`src/screens/Home.tsx`), replacing the previous commented-out placeholder. This ensures the work experience section is now visible on the homepage. [[1]](diffhunk://#diff-b268406df77026424a55d2412d5b6bd4b77ef5caa1b0fff1d6b8ceb299dd13a2R4) [[2]](diffhunk://#diff-b268406df77026424a55d2412d5b6bd4b77ef5caa1b0fff1d6b8ceb299dd13a2L23-R24)